### PR TITLE
Add -nocommands to email

### DIFF
--- a/Lidarr/email.sh
+++ b/Lidarr/email.sh
@@ -56,4 +56,4 @@ echo "${Message}"
 echo "."
 sleep 3
 echo "QUIT"
-) | openssl s_client -starttls smtp -connect $MailHost:$MailPort -crlf
+) | openssl s_client -starttls smtp -connect $MailHost:$MailPort -crlf -nocommands

--- a/Radarr/email.sh
+++ b/Radarr/email.sh
@@ -55,4 +55,4 @@ echo "${Message}"
 echo "."
 sleep 3
 echo "QUIT"
-) | openssl s_client -starttls smtp -connect $MailHost:$MailPort -crlf
+) | openssl s_client -starttls smtp -connect $MailHost:$MailPort -crlf -nocommands

--- a/Sonarr/email.sh
+++ b/Sonarr/email.sh
@@ -60,4 +60,4 @@ echo "${Message}"
 echo "."
 sleep 3
 echo "QUIT"
-) | openssl s_client -starttls smtp -connect $MailHost:$MailPort -crlf
+) | openssl s_client -starttls smtp -connect $MailHost:$MailPort -crlf -nocommands


### PR DESCRIPTION
As raised in issue #17  and referenced here: https://github.com/openssl/openssl/discussions/25218

Implemented the -nocommands option to the email.sh scripts for each app